### PR TITLE
Remove old repo directory

### DIFF
--- a/lib/sources/github.js
+++ b/lib/sources/github.js
@@ -1,3 +1,4 @@
+var fs = require('fs')
 var URL = require('url')
 var path = require('path')
 
@@ -7,6 +8,7 @@ var format = require('string-format')
 var urljoin = require('url-join')
 var gunzip = require('gunzip-maybe')
 var tar = require('tar')
+var rimraf = require('rimraf')
 
 var canProcess = function (name) {
   var url = URL.parse(name)
@@ -15,14 +17,26 @@ var canProcess = function (name) {
 
 var fetchSource = function (source, dir, next) {
   var tarUrl = urljoin(source, '/archive/master.tar.gz')
-  var tarStream = request(tarUrl)
-    .pipe(gunzip())
-    .pipe(tar.Extract({ path: dir, strip: 1 }))
-  .on('error', function (err) {
-     return next(err)
-  })
-  .on('end', function () {
-    next(null, dir)
+  function fetch () {
+    request(tarUrl)
+      .pipe(gunzip())
+      .pipe(tar.Extract({ path: dir, strip: 1 }))
+    .on('error', function (err) {
+      return next(err)
+    })
+    .on('end', function () {
+      next(null, dir)
+    })
+  }
+  fs.exists(dir, function (exists) {
+    if (exists) {
+      rimraf(path.resolve(dir), function (err) {
+        if (err) return next(err)
+        fetch()
+      })
+    } else {
+      fetch()
+    }
   })
 }
 var _processPath = function (source) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binder-build",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "A Binder module that constructs Docker images from requirements files and optionally pushes them to a registry",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "lodash": "^4.3.0",
     "mongoose": "^4.4.6",
     "request": "^2.67.0",
+    "rimraf": "^2.5.3",
     "shelljs": "^0.5.3",
     "string-format": "^0.5.0",
     "tar": "^2.2.1",


### PR DESCRIPTION
If a repository has previously been built, then the tarball extraction step will not delete the old repository contents, and will only create/overwrite existing files. 

Tested with multiple file creation/deletion steps on a dummy repository, and the old files were correctly removed from the new image.
