### PR TITLE
catch http errors downloading github repos

### DIFF
--- a/lib/sources/github.js
+++ b/lib/sources/github.js
@@ -39,13 +39,29 @@ var fetchTarball = function (source, dir, callback) {
   var options = { url: source.url + '/tarball/' + branch, headers: headers }
 
   request(options)
-    .pipe(gunzip())
-    .pipe(tar.Extract({ path: dir, strip: 1 }))
+    .on('response', function (resp) {
+      if (resp.statusCode >= 400) {
+        var err = new Error([
+          'Fetching',
+          options.url,
+          'failed:',
+          resp.statusCode,
+          resp.statusMessage,
+        ].join(' '));
+        return callback(err);
+      }
+      resp
+        .pipe(gunzip())
+        .pipe(tar.Extract({ path: dir, strip: 1 }))
+        .on('error', function (err) {
+          return callback(err)
+        })
+        .on('end', function () {
+          callback(null, dir)
+        })
+    })
     .on('error', function (err) {
       return callback(err)
-    })
-    .on('end', function () {
-      callback(null, dir)
     })
 }
 


### PR DESCRIPTION
should give a better error message when download fails, rather than "invalid tar file"

For example:

```
could not build image abc-xyz: Error: Fetching https://github.com/abc/xyz/tarball/master failed: 404 Not Found
```

May close https://github.com/binder-project/binder/issues/76
